### PR TITLE
WIP: Tutorial with pngcheck project

### DIFF
--- a/fuzzing-roadblocks/.gitignore
+++ b/fuzzing-roadblocks/.gitignore
@@ -1,0 +1,3 @@
+/.cifuzz-*/
+/pngcheck-*/
+lcov.info

--- a/fuzzing-roadblocks/CMakeLists.txt
+++ b/fuzzing-roadblocks/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.16)
+include(FetchContent)
+project(PngcheckFuzzing)
+
+# Enable cifuzz
+find_package(cifuzz)
+enable_fuzz_testing()
+
+# Obtain the pngcheck source code
+set(PNGCHECK_PRJ "pngcheck-3.0.3")
+set(PNGCHECK_DIR "${CMAKE_BINARY_DIR}/${PNGCHECK_PRJ}")
+FetchContent_Declare(pngcheck
+    URL "http://www.libpng.org/pub/png/src/${PNGCHECK_PRJ}.tar.gz"
+    URL_HASH SHA256=c36a4491634af751f7798ea421321642f9590faa032eccb0dd5fb4533609dee6
+    SOURCE_DIR ${PNGCHECK_DIR}
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+)
+if(NOT EXISTS ${PNGCHECK_DIR})
+    FetchContent_Populate(pngcheck)
+    # Rename the main function, so that we can
+    # later link the fuzzer with its own main.
+    execute_process(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} 
+        COMMAND sed -i "s/int main(/int original_main(/g" "${PNGCHECK_DIR}/pngcheck.c"
+    )
+endif()
+
+# Build target for our fuzz test
+add_fuzz_test(fuzztest
+    "fuzztest.cpp"
+    "print_wrapper.c"
+    "${PNGCHECK_DIR}/pngcheck.c"
+)
+target_link_options(fuzztest PRIVATE
+    "-Wl,--wrap=printf"
+    "-Wl,--wrap=fprintf"
+)

--- a/fuzzing-roadblocks/README.md
+++ b/fuzzing-roadblocks/README.md
@@ -1,0 +1,13 @@
+# Strategies for overcoming fuzzing roadblocks
+
+In many projects there are places where fuzzers can get stuck. This can happen for example when the software under test performs very specific checks on the input data before processing it further. For example, the validation of a checksum could be such a "fuzzing roadblock" or sometimes also simply a check for specific magic header bytes. In this example here, we will have a look at the software "pngcheck". Let's start by running the fuzz test for a while:
+```sh
+cifuzz run fuzztest
+```
+
+After running the fuzz test for a couple of minutes, we can have a look at the code coverage. To measure and export the coverage as an lcov file, use the following command:
+```sh
+cifuzz coverage -v --format=lcov -o lcov.info fuzztest
+```
+
+The [Coverage Gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters) extension for VS Code let's us then see which parts of the software were covered and which not.

--- a/fuzzing-roadblocks/cifuzz.yaml
+++ b/fuzzing-roadblocks/cifuzz.yaml
@@ -1,0 +1,46 @@
+## Configuration for a CI Fuzz project
+## Generated on 2023-05-11
+
+## The build system used to build this project. If not set, cifuzz tries
+## to detect the build system automatically.
+## Valid values: "bazel", "cmake", "maven", "gradle", "other".
+#build-system: cmake
+
+## If the build system type is "other", this command is used by
+## `cifuzz run` to build the fuzz test.
+#build-command: "make my_fuzz_test"
+
+## Directories containing sample inputs for the code under test.
+## See https://llvm.org/docs/LibFuzzer.html#corpus
+#seed-corpus-dirs:
+# - path/to/seed-corpus
+
+## A file containing input language keywords or other interesting byte
+## sequences.
+## See https://llvm.org/docs/LibFuzzer.html#dictionaries
+#dict: path/to/dictionary.dct
+
+## Command-line arguments to pass to libFuzzer.
+## See https://llvm.org/docs/LibFuzzer.html#options
+#engine-args:
+# - -rss_limit_mb=4096
+
+## Maximum time to run fuzz tests. The default is to run indefinitely.
+#timeout: 30m
+
+## By default, fuzz tests are executed in a sandbox to prevent accidental
+## damage to the system. Set to false to run fuzz tests unsandboxed.
+## Only supported on Linux.
+#use-sandbox: false
+
+## Set to true to print output of the `cifuzz run` command as JSON.
+#print-json: true
+
+## Set to true to disable desktop notifications
+#no-notifications: true
+
+## Set URL of the CI App
+#server: https://app.code-intelligence.com
+
+## Set the project name on the CI App
+#project: my-project-1a2b3c4d

--- a/fuzzing-roadblocks/fuzztest.cpp
+++ b/fuzzing-roadblocks/fuzztest.cpp
@@ -1,0 +1,17 @@
+#include <assert.h>
+#include <stdio.h>
+
+#include <cifuzz/cifuzz.h>
+#include <fuzzer/FuzzedDataProvider.h>
+
+// Declaration of the function we want to fuzz from pngcheck.c
+extern "C" int pngcheck(FILE *fp, const char *fname, int searching, FILE *fpOut);
+
+
+FUZZ_TEST(const uint8_t *data, size_t size) {
+  if(size == 0) return;
+
+  FILE *fp = fmemopen((void *) data, size, "rb");
+  int err = pngcheck(fp, "in-memory-dummy-file", 0, NULL);
+  fclose(fp);
+}

--- a/fuzzing-roadblocks/print_wrapper.c
+++ b/fuzzing-roadblocks/print_wrapper.c
@@ -1,0 +1,32 @@
+#include <stdarg.h>
+#include <stdio.h>
+
+// This file is used to stub print statements
+// from the fuzzed project, which can slow down
+// the fuzzing speed considerably if the system
+// under test is noisy.
+
+extern int __real_printf(const char*, ...);
+extern int __real_fprintf(FILE *stream, const char *format, ...);
+
+int __wrap_printf(const char* format, ...) {
+    va_list args;
+    va_start(args, format);
+    //__real_printf("[!] ");
+    //int result = vprintf(format, args);
+    va_end(args);
+
+    // Invalid return value, should return the number of bytes written, but this probably doesn't matter.
+    return 0;
+}
+
+int __wrap_fprintf(FILE *stream, const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+    //__real_printf("[!] ");
+    //int result = vprintf(format, args);
+    va_end(args);
+
+    // Invalid return value, should return the number of bytes written, but this probably doesn't matter.
+    return 0;
+}


### PR DESCRIPTION
I had set up the pngcheck project here since I thought there could be some interesting things to demonstrate. PNGs have CRC checksums, so I first wanted to show how the fuzzer would get stuck at the CRC check. Turns out, the tool only prints a warning if the CRC doesn't match, so that's maybe not too interesting here. Then, there are also lots of magic byte comparisons in there, e.g. `strcmp(chunkid, "IHDR")`, `strcmp(chunkid, "JHDR")`. This may be interesting, but it also turns out the fuzzer is surprisingly good to overcome those on its own when letting it run for some time. Maybe `use_value_profile=1` could still be a useful option to demonstrate here. Otherwise maybe show how a dictionary can easily be created out of those magic byte comparisons with a little bit of grep. This should allow the fuzzer to gain more code coverage even faster.